### PR TITLE
Remove unused `m_is_default` from `struct argument`

### DIFF
--- a/source/timemory/utility/argparse.cpp
+++ b/source/timemory/utility/argparse.cpp
@@ -985,7 +985,7 @@ argument_parser::parse(const std::vector<std::string>& _args, int verbose_level)
     // execute the argument-specific actions
     for(auto& itr : m_arg_map)
     {
-        if(exists(itr.first) || itr.second->m_is_default)
+        if(exists(itr.first) || itr.second->m_default)
             itr.second->execute_actions(*this);
     }
 

--- a/source/timemory/utility/argparse.hpp
+++ b/source/timemory/utility/argparse.hpp
@@ -718,7 +718,6 @@ struct argument_parser
         bool is_separator() const;
 
         friend struct argument_parser;
-        bool                       m_is_default     = false;
         int                        m_position       = Position::IgnoreArgument;
         int                        m_count          = Count::ANY;
         int                        m_min_count      = Count::ANY;


### PR DESCRIPTION
It was used in the argparser and caused the argument action not being called leading to default values not being recognized. 