### PR TITLE
Update rpath on libunwind libraries

### DIFF
--- a/cmake/Modules/ConfigLibunwind.cmake
+++ b/cmake/Modules/ConfigLibunwind.cmake
@@ -161,10 +161,13 @@ foreach(_LIB ${libunwind_libs})
         execute_process(COMMAND ${CMAKE_STRIP} ${_LIB})
         find_program(CHRPATH_EXECUTABLE chrpath)
 
-        if (CHRPATH_EXECUTABLE)
+        if(CHRPATH_EXECUTABLE)
             execute_process(COMMAND ${CHRPATH_EXECUTABLE} -r "$ORIGIN" ${_LIB})
         else()
-            message(WARNING "[timemory] chrpath not found. Skipping rpath modification for libunwind.")
+            message(
+                WARNING
+                    "[timemory] chrpath not found. Skipping rpath modification for libunwind."
+                )
         endif()
     endif()
 

--- a/cmake/Modules/ConfigLibunwind.cmake
+++ b/cmake/Modules/ConfigLibunwind.cmake
@@ -159,6 +159,13 @@ foreach(_LIB ${libunwind_libs})
 
     if("${_LIB}" MATCHES "\\.so($|\\.)")
         execute_process(COMMAND ${CMAKE_STRIP} ${_LIB})
+        find_program(CHRPATH_EXECUTABLE chrpath)
+
+        if (CHRPATH_EXECUTABLE)
+            execute_process(COMMAND ${CHRPATH_EXECUTABLE} -r "$ORIGIN" ${_LIB})
+        else()
+            message(WARNING "[timemory] chrpath not found. Skipping rpath modification for libunwind.")
+        endif()
     endif()
 
     install(


### PR DESCRIPTION
Invalid RPATH used for libunwind properties. Failing RPM generations and rpath check on RHEL 10. 

```
Full Error log can be obtained from the third column. 

ERROR   0002: file '/opt/rocm-6.5.0/lib/rocprofiler-systems/libunwind-setjmp.so.0.0.0' contains an invalid rpath '/longer_pathname_so_that_rpms_can_support_packaging_the_debug_info_for_all_os_profiles/src/out/rhel-10.0/10.0/build/rocprofiler-systems/external/timemory/external/libunwind/install/lib' in [/longer_pathname_so_that_rpms_can_support_packaging_the_debug_info_for_all_os_profiles/src/out/rhel-10.0/10.0/build/rocprofiler-systems/external/timemory/external/libunwind/install/lib]
ERROR   0002: file '/opt/rocm-6.5.0/lib/rocprofiler-systems/libunwind-x86_64.so.99.0.0' contains an invalid rpath '/longer_pathname_so_that_rpms_can_support_packaging_the_debug_info_for_all_os_profiles/src/out/rhel-10.0/10.0/build/rocprofiler-systems/external/timemory/external/libunwind/install/lib' in [/longer_pathname_so_that_rpms_can_support_packaging_the_debug_info_for_all_os_profiles/src/out/rhel-10.0/10.0/build/rocprofiler-systems/external/timemory/external/libunwind/install/lib]
error: Bad exit status from /var/tmp/rpm-tmp.hPrq3C (%install)
    line 22: It's not recommended to have unversioned Obsoletes: Obsoletes: omnitrace
    Bad exit status from /var/tmp/rpm-tmp.hPrq3C (%install)
```