### PR TITLE
Prevent sampling when thread is shutting down

### DIFF
--- a/source/timemory/process/threading.hpp
+++ b/source/timemory/process/threading.hpp
@@ -268,7 +268,7 @@ inline thread_local bool is_shutting_down = false;
 
 inline void set_is_shutting_down(bool shutting_down = true)
 {
-    is_shutting_down = is_shutting_down;
+    is_shutting_down = shutting_down;
 }
 
 inline bool get_is_shutting_down()

--- a/source/timemory/process/threading.hpp
+++ b/source/timemory/process/threading.hpp
@@ -264,6 +264,17 @@ struct affinity
 //
 //--------------------------------------------------------------------------------------//
 //
+inline thread_local bool is_shutting_down = false;
+
+inline void set_is_shutting_down(bool shutting_down = true)
+{
+    is_shutting_down = is_shutting_down;
+}
+
+inline bool get_is_shutting_down()
+{
+    return is_shutting_down;
+}
 }  // namespace threading
 }  // namespace tim
 

--- a/source/timemory/sampling/sampler.cpp
+++ b/source/timemory/sampling/sampler.cpp
@@ -380,7 +380,7 @@ template <template <typename...> class CompT, size_t N, typename... Types>
 void
 sampler<CompT<Types...>, N>::execute(int signum)
 {
-    if(!trait::runtime_enabled<this_type>::get())
+    if(!trait::runtime_enabled<this_type>::get() || threading::get_is_shutting_down())
         return;
 
     // save errno
@@ -411,7 +411,7 @@ template <template <typename...> class CompT, size_t N, typename... Types>
 void
 sampler<CompT<Types...>, N>::execute(int signum, siginfo_t* _info, void* _data)
 {
-    if(!trait::runtime_enabled<this_type>::get())
+    if(!trait::runtime_enabled<this_type>::get() || threading::get_is_shutting_down())
         return;
 
     // save errno


### PR DESCRIPTION
This fix aims to prevent sampling when the timemory thread is being shutdown by rocprof-sys.