### PR TITLE
Enable string to be copied in print_help

### DIFF
--- a/source/timemory/utility/argparse.cpp
+++ b/source/timemory/utility/argparse.cpp
@@ -289,7 +289,7 @@ argument_parser::enable_help()
 TIMEMORY_UTILITY_INLINE
 // clang-format on
 argument_parser::argument&
-argument_parser::enable_help(const std::string& _extra, const std::string& _epilogue,
+argument_parser::enable_help(const std::string _extra, const std::string _epilogue,
                              int _exit_code)
 {
     m_help_enabled = true;
@@ -414,7 +414,7 @@ argument_parser::enable_version(
 TIMEMORY_UTILITY_INLINE
 // clang-format on
 void
-argument_parser::print_help(const std::string& _extra, const std::string& _epilogue)
+argument_parser::print_help(const std::string _extra, const std::string _epilogue)
 {
     end_group();
 

--- a/source/timemory/utility/argparse.hpp
+++ b/source/timemory/utility/argparse.hpp
@@ -874,7 +874,7 @@ struct argument_parser
     //
     //----------------------------------------------------------------------------------//
     //
-    void print_help(const std::string& _extra = {}, const std::string& _epilogue = {});
+    void print_help(const std::string _extra = {}, const std::string _epilogue = {});
     //
     //----------------------------------------------------------------------------------//
     //
@@ -981,7 +981,7 @@ struct argument_parser
 
     /// \fn argument& enable_help()
     /// \brief Add a help command
-    argument& enable_help(const std::string& _extra, const std::string& _epilogue = {},
+    argument& enable_help(const std::string _extra, const std::string _epilogue = {},
                           int _exit_code = EXIT_SUCCESS);
 
     /// \fn argument& enable_version(


### PR DESCRIPTION
## Motivation
Rocprofiler-systems application is crashing while trying to print help.

## Technical Details
String is passed as reference and captured by lambda, while lifetime of string is shorter than lifetime of lambda. This is causing segmentation fault.
