### PR TITLE
Upgrade version of binutils package built as binutils-external

### DIFF
--- a/cmake/Modules/ConfigBinutils.cmake
+++ b/cmake/Modules/ConfigBinutils.cmake
@@ -75,8 +75,8 @@ externalproject_add(
     binutils-external
     PREFIX ${PROJECT_BINARY_DIR}/external/binutils
     URL ${TIMEMORY_BINUTILS_DOWNLOAD_URL}
-        http://ftpmirror.gnu.org/gnu/binutils/binutils-2.42.tar.gz
-        http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.42.tar.gz
+        http://ftpmirror.gnu.org/gnu/binutils/binutils-2.45.tar.gz
+        http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.45.tar.gz
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND
         ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3


### PR DESCRIPTION
## Motivation

Use the same version of biunutils package across rocprofiler-systems

## Technical Details

Aligned the versions of binutils package as the one provided within rocprofiler-systems
