### PR TITLE
Fixed code to strictly correct C++ so that Clang 20 would accept it

### DIFF
--- a/source/timemory/tpls/cereal/cereal/types/tuple.hpp
+++ b/source/timemory/tpls/cereal/cereal/types/tuple.hpp
@@ -101,7 +101,7 @@ struct serialize
     template <class Archive, class... Types>
     inline static void apply(Archive& ar, std::tuple<Types...>& tuple)
     {
-        serialize<Height - 1>::template apply(ar, tuple);
+        serialize<Height - 1>::template apply<>(ar, tuple);
         ar(TIMEMORY_CEREAL_NVP_(tuple_element_name<Height - 1>::c_str(),
                                 std::get<Height - 1>(tuple)));
     }
@@ -123,7 +123,7 @@ template <class Archive, class... Types>
 inline void
 TIMEMORY_CEREAL_SERIALIZE_FUNCTION_NAME(Archive& ar, std::tuple<Types...>& tuple)
 {
-    tuple_detail::serialize<std::tuple_size<std::tuple<Types...>>::value>::template apply(
+    tuple_detail::serialize<std::tuple_size<std::tuple<Types...>>::value>::template apply<>(
         ar, tuple);
 }
 }  // namespace cereal


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
The code before the fix would not compile on Clang 20 or later.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
When the template keyword is used as a hint to the compiler that the identifier is a template name, we strictly have to put the list of parameters after the identifiers, even if it is empty. GCC and Clang before version 20 were lenient, but this change makes the code conform to the standard.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
