### PR TITLE
Exclude perf_event_uncore events from evaluation

### DIFF
--- a/source/timemory/backends/papi.cpp
+++ b/source/timemory/backends/papi.cpp
@@ -39,6 +39,7 @@
 
 #include <regex>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -277,8 +278,8 @@ get_event_code(string_view_cref_t event_code_str)
     int event_code = -1;
     int retval     = PAPI_event_name_to_code(event_code_str.data(), &event_code);
     working()      = check(retval, TIMEMORY_JOIN(' ', "Warning!! Failure converting",
-                                            event_code_str, "to enum value")
-                                  .c_str());
+                                                 event_code_str, "to enum value")
+                                       .c_str());
     return (retval == PAPI_OK) ? event_code : PAPI_NOT_INITED;
 #else
     consume_parameters(event_code_str);
@@ -401,15 +402,7 @@ add_events(int event_set, string_t* events, int number)
 
 TIMEMORY_BACKENDS_INLINE
 hwcounter_info_t
-available_events_info()
-{
-    // Delegate to the overloaded version with no exclusions
-    return available_events_info(std::vector<std::string>{});
-}
-
-TIMEMORY_BACKENDS_INLINE
-hwcounter_info_t
-available_events_info(const std::vector<std::string>& excluded_components)
+available_events_info(const std::unordered_set<std::string>& excluded_components)
 {
     hwcounter_info_t evts{};
 
@@ -537,16 +530,7 @@ available_events_info(const std::vector<std::string>& excluded_components)
 #    endif
 
             // Skip excluded components
-            bool should_skip = false;
-            for(const auto& excluded : excluded_components)
-            {
-                if(strcmp(component->name, excluded.c_str()) == 0)
-                {
-                    should_skip = true;
-                    break;
-                }
-            }
-            if(should_skip)
+            if(excluded_components.count(component->name) > 0)
                 continue;
 
             // show this component has not found any events yet

--- a/source/timemory/backends/papi.cpp
+++ b/source/timemory/backends/papi.cpp
@@ -403,6 +403,14 @@ TIMEMORY_BACKENDS_INLINE
 hwcounter_info_t
 available_events_info()
 {
+    // Delegate to the overloaded version with no exclusions
+    return available_events_info(std::vector<std::string>{});
+}
+
+TIMEMORY_BACKENDS_INLINE
+hwcounter_info_t
+available_events_info(const std::vector<std::string>& excluded_components)
+{
     hwcounter_info_t evts{};
 
 #if defined(TIMEMORY_USE_PAPI)
@@ -527,6 +535,19 @@ available_events_info()
             if(component->disabled != 0)
                 continue;
 #    endif
+
+            // Skip excluded components
+            bool should_skip = false;
+            for(const auto& excluded : excluded_components)
+            {
+                if(strcmp(component->name, excluded.c_str()) == 0)
+                {
+                    should_skip = true;
+                    break;
+                }
+            }
+            if(should_skip)
+                continue;
 
             // show this component has not found any events yet
             // int num_cmp_events = 0;

--- a/source/timemory/backends/papi.hpp
+++ b/source/timemory/backends/papi.hpp
@@ -254,7 +254,7 @@ check(int retval, string_view_cref_t mesg, bool quiet = false)
 #if defined(TIMEMORY_USE_PAPI)
         auto*  error_str = PAPI_strerror(retval);
         auto&& _msg      = TIMEMORY_JOIN(' ', "[timemory][papi]", mesg, ":: PAPI_error",
-                                    retval, ":", error_str);
+                                         retval, ":", error_str);
         if(settings::papi_fail_on_error())
         {
             TIMEMORY_EXCEPTION(_msg);
@@ -1023,10 +1023,7 @@ overflow(int evt_set, string_view_cref_t evt_name, int threshold, int flags,
 //--------------------------------------------------------------------------------------//
 
 hwcounter_info_t
-available_events_info();
-
-hwcounter_info_t
-available_events_info(const std::vector<std::string>& excluded_components);
+available_events_info(const std::unordered_set<std::string>& excluded_components = {});
 
 //--------------------------------------------------------------------------------------//
 

--- a/source/timemory/backends/papi.hpp
+++ b/source/timemory/backends/papi.hpp
@@ -1025,6 +1025,9 @@ overflow(int evt_set, string_view_cref_t evt_name, int threshold, int flags,
 hwcounter_info_t
 available_events_info();
 
+hwcounter_info_t
+available_events_info(const std::vector<std::string>& excluded_components);
+
 //--------------------------------------------------------------------------------------//
 
 tim::hardware_counters::info


### PR DESCRIPTION
## Motivation

When profiling with PAPI_enum_cmp_event() or initializing PAPI components, the application appeared to “hang” on Intel systems but completed normally on AMD EPYC systems.
PAPI uses libpfm4 and the Linux perf_event subsystem to enumerate available hardware counters from /sys/devices/.

On Intel system exposes a very large number of uncore performance monitoring units (PMUs) under /sys/devices/,
The PAPI perf_event_uncore component attempts to enumerate every one of these uncore PMUs and their associated events through libpfm.
On AMD EPYC systems, /sys/devices/ only contains a few entries such as amd_iommu_* and no uncore PMU directories, so enumeration completes almost instantly.

Enumerating through this large number of perf_event_uncore events cause a hang like situation for a long time.

## Technical Details

Modify the available_events_info to accept an exclude event name which can be passed from applications so rocprofiler-systems can call exclude with perf_event_uncore as the argument to avoid the hang on Intel systems.

An issue is raised with PAPI repo for this issue:  https://github.com/icl-utk-edu/papi/issues/502 

## Test Plan

Tested manually on the Intel system where the problem was happening.

## Test Result

No hangs during initialization was observed after excluding perf_event_uncore .

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
