### PR TITLE
Update the ConfigLibunwind.cmake

### DIFF
--- a/cmake/Modules/ConfigLibunwind.cmake
+++ b/cmake/Modules/ConfigLibunwind.cmake
@@ -160,13 +160,16 @@ foreach(_LIB ${libunwind_libs})
     if("${_LIB}" MATCHES "\\.so($|\\.)")
         execute_process(COMMAND ${CMAKE_STRIP} ${_LIB})
         find_program(CHRPATH_EXECUTABLE chrpath)
+        find_program(PATCHELF_EXECUTABLE patchelf)
 
         if(CHRPATH_EXECUTABLE)
             execute_process(COMMAND ${CHRPATH_EXECUTABLE} -r "$ORIGIN" ${_LIB})
+        elseif(PATCHELF_EXECUTABLE)
+            execute_process(COMMAND ${PATCHELF_EXECUTABLE} --set-rpath "$ORIGIN" ${_LIB})
         else()
             message(
-                WARNING
-                    "[timemory] chrpath not found. Skipping rpath modification for libunwind."
+                AUTHOR_WARNING
+                    "[timemory] Neither chrpath nor patchelf found. Skipping rpath modification for libunwind."
                 )
         endif()
     endif()


### PR DESCRIPTION
## Motivation

Clean up "scary" build logs if your build system does not have "chrpath" present.
Use patchelf, since it is the more common utility.

## Technical Details

Fallback to use `patchelf`, if `chrpath` is not present. 
Change some logging from "WARNING"s to "AUTHOR_WARNING"s.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
