### PR TITLE
prioritize GNU libunwind headers over system LLVM libunwind usin…

### DIFF
--- a/cmake/Modules/ConfigLibunwind.cmake
+++ b/cmake/Modules/ConfigLibunwind.cmake
@@ -185,8 +185,10 @@ install(
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/timemory/libunwind/pkgconfig
     OPTIONAL)
 
+# Add include directories with BEFORE to ensure they come first in include search path
+# This ensures GNU libunwind headers are found before LLVM libunwind headers
 target_include_directories(
-    timemory-libunwind SYSTEM
+    timemory-libunwind BEFORE
     INTERFACE $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/external/libunwind/install/include>
               $<INSTALL_INTERFACE:include/timemory/libunwind>)
 target_link_directories(


### PR DESCRIPTION
Solves : SWDEV-559349

## Motivation

This pull request makes a targeted change to the `ConfigLibunwind.cmake` file to improve how include directories are handled for the `timemory-libunwind` target. The update ensures that the correct version of libunwind headers is prioritized during the build process.

Include directory handling:

* Changed the `target_include_directories` command to use the `BEFORE` keyword instead of `SYSTEM`, ensuring that GNU libunwind headers are found before LLVM libunwind headers in the include search path.…g BEFORE keyword

## Technical Details

When building rocprofiler-systems on systems with ROCm installed, the compiler was finding LLVM's libunwind headers (/opt/rocm-*/llvm/include/) before the GNU libunwind headers that timemory builds internally. This caused compilation errors because:
LLVM libunwind is a minimal implementation focused on C++ exception handling
GNU libunwind (nongnu.org) provides additional APIs like unw_frame_regnum_t that timemory uses for stack unwinding

## Test Plan

Verified on aac6 cluster and ubuntu local machine.

## Test Result

Its building and compiling the code.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
