### PR TITLE
Eliminate parallel-build race conditions in cmake for binutils

### DIFF
--- a/cmake/Modules/ConfigBinutils.cmake
+++ b/cmake/Modules/ConfigBinutils.cmake
@@ -38,11 +38,7 @@ file(GLOB_RECURSE _TIMEMORY_BINUTILS_BUILD_BYPRODUCTS_GLOB
      ${PROJECT_BINARY_DIR}/external/binutils/src/binutils-external/*.a)
 
 set(_TIMEMORY_BINUTILS_BUILD_BYPRODUCTS
-    ${_TIMEMORY_BINUTILS_BUILD_BYPRODUCTS_GLOB}
-    ${PROJECT_BINARY_DIR}/external/tpls/lib/libbfd.a
-    ${PROJECT_BINARY_DIR}/external/tpls/lib/libopcodes.a
-    ${PROJECT_BINARY_DIR}/external/tpls/lib/libiberty.a
-    ${PROJECT_BINARY_DIR}/external/tpls/lib/libsframe.a)
+    ${_TIMEMORY_BINUTILS_BUILD_BYPRODUCTS_GLOB})
 
 foreach(
     _FILE
@@ -50,7 +46,6 @@ foreach(
     ${PROJECT_BINARY_DIR}/external/binutils/src/binutils-external/opcodes/.libs/libopcodes.a
     ${PROJECT_BINARY_DIR}/external/binutils/src/binutils-external/libsframe/.libs/libsframe.a
     ${PROJECT_BINARY_DIR}/external/binutils/src/binutils-external/bfd/.libs/libbfd.a
-    ${PROJECT_BINARY_DIR}/external/binutils/src/binutils-external/bfd/libbfd.a
     ${PROJECT_BINARY_DIR}/external/binutils/src/binutils-external/libiberty/libiberty.a)
     if(NOT "${_FILE}" IN_LIST _TIMEMORY_BINUTILS_BUILD_BYPRODUCTS)
         list(APPEND _TIMEMORY_BINUTILS_BUILD_BYPRODUCTS ${_FILE})
@@ -84,11 +79,12 @@ externalproject_add(
         --prefix=${TPL_STAGING_PREFIX} ${_binutils_CONFIG_FLAGS}
     BUILD_COMMAND ${MAKE_COMMAND} all-libiberty all-bfd all-opcodes all-libsframe
     INSTALL_COMMAND ""
+    CONFIGURE_HANDLED_BY_BUILD TRUE
     BUILD_BYPRODUCTS "${_TIMEMORY_BINUTILS_BUILD_BYPRODUCTS}")
 
 add_custom_command(
-    TARGET binutils-external
-    POST_BUILD
+    OUTPUT ${TPL_STAGING_PREFIX}/lib/libbfd.a ${TPL_STAGING_PREFIX}/lib/libopcodes.a
+           ${TPL_STAGING_PREFIX}/lib/libiberty.a ${TPL_STAGING_PREFIX}/lib/libsframe.a
     COMMAND ${CMAKE_COMMAND} ARGS -E make_directory ${TPL_STAGING_PREFIX}/lib
     COMMAND
         install ARGS -C
@@ -97,8 +93,15 @@ add_custom_command(
         ${PROJECT_BINARY_DIR}/external/binutils/src/binutils-external/libiberty/libiberty.a
         ${PROJECT_BINARY_DIR}/external/binutils/src/binutils-external/libsframe/.libs/libsframe.a
         ${TPL_STAGING_PREFIX}/lib/
+    DEPENDS binutils-external
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/external/binutils/src/binutils-external
     COMMENT "Installing binutils...")
+
+add_custom_target(binutils-install ALL DEPENDS
+    ${TPL_STAGING_PREFIX}/lib/libbfd.a
+    ${TPL_STAGING_PREFIX}/lib/libopcodes.a
+    ${TPL_STAGING_PREFIX}/lib/libiberty.a
+    ${TPL_STAGING_PREFIX}/lib/libsframe.a)
 
 foreach(_NAME bfd opcodes iberty sframe)
     set(_FILE
@@ -107,7 +110,7 @@ foreach(_NAME bfd opcodes iberty sframe)
 
     add_library(binutils::${_NAME}-library STATIC IMPORTED)
     set_property(TARGET binutils::${_NAME}-library PROPERTY IMPORTED_LOCATION ${_FILE})
-    add_dependencies(binutils::${_NAME}-library binutils-external)
+    add_dependencies(binutils::${_NAME}-library binutils-install)
 endforeach()
 
 find_package(ZLIB)


### PR DESCRIPTION
## Motivation

- Fix parallel-build race conditions in the CMake binutils external project by replacing the POST_BUILD custom command with an OUTPUT-based custom command and a dedicated binutils-install target, ensuring proper  dependency ordering

## Technical Details

The previous POST_BUILD custom command on binutils-external had two race condition issues during parallel builds (make -jN / ninja):

1. Missing dependency edge from install to build: The POST_BUILD step copies .a files into the staging prefix, but downstream imported targets (binutils::<name>-library) depended directly on binutils-external. In a parallel build, a consumer could start linking before the copy completed.
3. No rebuild tracking: POST_BUILD commands always run and don't participate in CMake's dependency graph for determining whether outputs are up-to-date.

  The fix:
- Converts the POST_BUILD custom command to an OUTPUT-based add_custom_command that produces the four staged .a files, with an explicit DEPENDS binutils-external
- Adds a new binutils-install custom target that depends on those output files
- Changes binutils::<name>-library imported targets to depend on binutils-install instead of binutils-external, ensuring the copy step completes before any consumer links
- Adds CONFIGURE_HANDLED_BY_BUILD TRUE to avoid unnecessary reconfigures
- Removes a stale bfd/libbfd.a path (non-.libs variant) from the byproducts list
- Removes hardcoded staging-prefix paths from _TIMEMORY_BINUTILS_BUILD_BYPRODUCTS since they are now tracked via the OUTPUT command

 
## Test Plan

- Verify cmake --build . -j$(nproc) completes without missing-file errors on a clean build
- Verify incremental rebuilds correctly skip the binutils install step when artifacts are already up-to-date
- Confirm binutils-dependent targets (e.g., timemory-bfd) link successfully
 
## Test Result

Passed.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
