### PR TITLE
Correct compiler flags and binutils url

### DIFF
--- a/cmake/Modules/ConfigBinutils.cmake
+++ b/cmake/Modules/ConfigBinutils.cmake
@@ -70,14 +70,14 @@ externalproject_add(
     binutils-external
     PREFIX ${PROJECT_BINARY_DIR}/external/binutils
     URL ${TIMEMORY_BINUTILS_DOWNLOAD_URL}
-        http://ftpmirror.gnu.org/gnu/binutils/binutils-2.46.0.tar.gz
-        http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.46.0.tar.gz
+        https://ftpmirror.gnu.org/gnu/binutils/binutils-2.46.0.tar.gz
+        https://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.46.0.tar.gz
     BUILD_IN_SOURCE 1
     CONFIGURE_COMMAND
         ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER}
-        CFLAGS=-fPIC\ -O3\ -Wno-maybe-uninitialized\ -Wno-format-truncation
+        CFLAGS=-fPIC\ -O3\ -Wno-error
         CXX=${CMAKE_CXX_COMPILER}
-        CXXFLAGS=-fPIC\ -O3\ -Wno-maybe-uninitialized\ -Wno-format-truncation
+        CXXFLAGS=-fPIC\ -O3\ -Wno-error
         <SOURCE_DIR>/configure --prefix=${TPL_STAGING_PREFIX} ${_binutils_CONFIG_FLAGS}
     BUILD_COMMAND ${MAKE_COMMAND} all-libiberty all-bfd all-opcodes all-libsframe
     INSTALL_COMMAND ""


### PR DESCRIPTION
## Motivation

Update the binutils url to use https and modify the compiler flags to fix building with clang.

## Technical Details

Update the binutils url to use https and modify the compiler flags.

## Test Plan

Manual tests and verification.

## Test Result

Pass

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
