### PR TITLE
update libunwind to official 1.7.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,7 +33,7 @@
 	url = https://android.googlesource.com/platform/external/perfetto
 [submodule "external/libunwind"]
 	path = external/libunwind
-	url = https://github.com/jrmadsen/libunwind.git
+	url = https://github.com/libunwind/libunwind.git
 [submodule "external/yaml-cpp"]
 	path = external/yaml-cpp
 	url = https://github.com/jrmadsen/yaml-cpp.git

--- a/cmake/Modules/Packages.cmake
+++ b/cmake/Modules/Packages.cmake
@@ -1139,7 +1139,7 @@ elseif(TIMEMORY_USE_LIBUNWIND AND TIMEMORY_BUILD_LIBUNWIND)
         RELATIVE_PATH external/libunwind
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         REPO_URL https://github.com/libunwind/libunwind.git
-        REPO_BRANCH v1.8.3)
+        REPO_BRANCH v1.7.2)
 
     include(ConfigLibunwind)
 else()

--- a/cmake/Modules/Packages.cmake
+++ b/cmake/Modules/Packages.cmake
@@ -1138,8 +1138,8 @@ elseif(TIMEMORY_USE_LIBUNWIND AND TIMEMORY_BUILD_LIBUNWIND)
         RECURSIVE
         RELATIVE_PATH external/libunwind
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-        REPO_URL https://github.com/jrmadsen/libunwind.git
-        REPO_BRANCH master)
+        REPO_URL https://github.com/libunwind/libunwind.git
+        REPO_BRANCH v1.8.3)
 
     include(ConfigLibunwind)
 else()


### PR DESCRIPTION
## Motivation

Update libunwind from v1.6-rc1 from private fork to v1.7.2 from official repository

## Technical Details

Current libunwind version is 1.8.3, but versions after v.1.7.2 produce multiple segmentation faults in rocprofiler-systems tests. Using the latest version requires further investigation.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
