### PR TITLE
Fix reversed trinaries in manager

### DIFF
--- a/source/timemory/manager/manager.hpp
+++ b/source/timemory/manager/manager.hpp
@@ -389,8 +389,8 @@ private:
     /// suppresses the exit hook during termination
     static bool& f_use_exit_hook() { return f_manager_persistent_data().use_exit_hook; }
     static auto  f_settings() { return f_manager_persistent_data().config; }
-    static auto  f_debug() { return f_settings() ? false : f_settings()->get_debug(); }
-    static auto  f_verbose() { return f_settings() ? 0 : f_settings()->get_verbose(); }
+    static auto  f_debug() { return f_settings() ? f_settings()->get_debug() : false; }
+    static auto  f_verbose() { return f_settings() ? f_settings()->get_verbose() : 0; }
 
 public:
     /// This function stores the primary manager instance for the application


### PR DESCRIPTION
## Motivation

Manager class had a bug: reversed trinaries in f_debug() and f_verbose() methods. As a result, these settings were read incorrectly.

## Technical Details

Trinaries reversed to the correct state

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
