### PR TITLE
Add CODEOWNERS file for ROCm project

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ROCm/rocprof-sys


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
Setting default CODEOWNERS for the `rocprofiler-systems` branch.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Add `@ROCm/rocprof-sys` as the default CODEOWNER on the branch

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
