### PR TITLE
C++20 support for rocprofiler-systems-20 branch

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -34,7 +34,7 @@ environment:
   CONTINUOUS_INTEGRATION: "true"
   matrix:
     - CONDA: 38
-      CPP: 17
+      CPP: 20
       CONFIG: Release
       TOOLS: "OFF"
       WINSOCK: "OFF"
@@ -47,7 +47,7 @@ environment:
       BUILD_EXAMPLES: "OFF"
       RUN_EXAMPLES: "OFF"
     - PYTHON: 37
-      CPP: 14
+      CPP: 20
       CONFIG: Debug
       TOOLS: "ON"
       WINSOCK: "OFF"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,7 +80,7 @@ jobs:
             --disable-vtune
             --disable-build-caliper
             --disable-build-gotcha
-            --cxx-standard=17
+            --cxx-standard=20
             -- -DTIMEMORY_REQUIRE_PACKAGES=OFF -DTIMEMORY_BUILD_COMPILER_INSTRUMENTATION=OFF -DTIMEMORY_BUILD_KOKKOS_CONFIG=OFF -DTIMEMORY_UNITY_BUILD=OFF -DTIMEMORY_USE_LIBUNWIND=OFF -- -j1 &&
             rm -f .hold &&
             SUBPACKAGES="api bundle common component hardware_counters mpi bundle options plotting profiler region roofline settings signals trace units util";
@@ -123,7 +123,7 @@ jobs:
             --gotcha
             --stats
             --tools mpip mallocp dyninst kokkos
-            --cxx-standard=17
+            --cxx-standard=20
             --compile-time-perf ${HOME}/ctp
             -- -V --output-on-failure
             -- -DTIMEMORY_BUILD_{CALIPER,GOTCHA,COMPILER_INSTRUMENTATION}=OFF -DTIMEMORY_UNITY_BUILD=OFF -DCMAKE_INSTALL_PREFIX=${HOME}/timemory-install
@@ -174,7 +174,7 @@ jobs:
             --mpi
             --gotcha
             --tools mpip mallocp dyninst
-            --cxx-standard=17
+            --cxx-standard=20
             -j 2
             -- -V --output-on-failure -E dynamic_instrument
             -- -DTIMEMORY_BUILD_{CALIPER,GOTCHA,COMPILER_INSTRUMENTATION}=OFF -DCMAKE_INSTALL_PREFIX=${HOME}/timemory-install &&
@@ -229,7 +229,7 @@ jobs:
             --dart
             --cuda
             --tools avail
-            --cxx-standard=17
+            --cxx-standard=20
             --compile-time-perf ${HOME}/ctp
             -- -V --output-on-failure -E cuda
             -- -DTIMEMORY_BUILD_{CALIPER,GOTCHA,COMPILER_INSTRUMENTATION}=OFF -DPYTHON_EXECUTABLE=$(which python) -DTIMEMORY_BUILD_ERT=OFF -DCMAKE_INSTALL_PREFIX=${HOME}/timemory-install
@@ -273,7 +273,7 @@ jobs:
             --dart
             --python
             --tools avail timem
-            --cxx-standard=17
+            --cxx-standard=20
             --compile-time-perf ${HOME}/ctp
             -- -V --output-on-failure
             -- -DTIMEMORY_BUILD_{CALIPER,COMPILER_INSTRUMENTATION}=OFF -DPYTHON_EXECUTABLE=$(which python) -DTIMEMORY_BUILD_PYTHON_HATCHET=OFF -DCMAKE_INSTALL_PREFIX=${HOME}/timemory-install

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -23,7 +23,7 @@ jobs:
             PYTHON_VERSION: '3.6'
             BUILD_TYPE: 'MinSizeRel'
             PACKAGES: 'clang-9 build-essential libopenmpi-dev openmpi-bin openmpi-common libfabric-dev ccache graphviz'
-            BUILD_ARGS: '--quick --build-libs shared --mpi --gotcha --tools mallocp mpip ompt --cxx-standard=17'
+            BUILD_ARGS: '--quick --build-libs shared --mpi --gotcha --tools mallocp mpip ompt --cxx-standard=20'
             CTEST_ARGS: '-V --output-on-failure'
             CONFIG_ARGS: '-DTIMEMORY_CCACHE_BUILD=ON'
           - CC: clang-10
@@ -31,7 +31,7 @@ jobs:
             PYTHON_VERSION: '3.7'
             BUILD_TYPE: 'Release'
             PACKAGES: 'clang-10 build-essential ccache graphviz'
-            BUILD_ARGS: '--minimal --build-libs shared static --python --gotcha --stats --unwind --tools mallocp --cxx-standard=17'
+            BUILD_ARGS: '--minimal --build-libs shared static --python --gotcha --stats --unwind --tools mallocp --cxx-standard=20'
             CTEST_ARGS: '-V --output-on-failure'
             CONFIG_ARGS: '-DTIMEMORY_CCACHE_BUILD=ON -DTIMEMORY_UNITY_BUILD=OFF -DTIMEMORY_BUILD_PYTHON_UNITY=OFF'
           - CC: clang-11
@@ -39,7 +39,7 @@ jobs:
             PYTHON_VERSION: '3.7'
             BUILD_TYPE: 'Release'
             PACKAGES: 'clang-11 build-essential ccache graphviz'
-            BUILD_ARGS: '--minimal --build-libs shared static --stats --tools kokkos-config timem --cxx-standard=17'
+            BUILD_ARGS: '--minimal --build-libs shared static --stats --tools kokkos-config timem --cxx-standard=20'
             CONFIG_ARGS: '-DTIMEMORY_CCACHE_BUILD=ON'
           - CC: gcc-7
             CXX: g++-7
@@ -47,7 +47,7 @@ jobs:
             PYTHON_VERSION: '3.6'
             BUILD_TYPE: 'Debug'
             PACKAGES: 'gcc-7 g++-7 gfortran-7 build-essential libmpich-dev mpich libtbb-dev libpapi-dev papi-tools lcov ccache graphviz'
-            BUILD_ARGS: '--minimal --build-libs shared --mpi --papi --gotcha --unwind --tools mpip --stats --cxx-standard=17 --coverage'
+            BUILD_ARGS: '--minimal --build-libs shared --mpi --papi --gotcha --unwind --tools mpip --stats --cxx-standard=20 --coverage'
             CTEST_ARGS: '-V --output-on-failure'
             CONFIG_ARGS: '-DCMAKE_C_FLAGS=-Og -DCMAKE_CXX_FLAGS=-Og'
           - CC: gcc-8
@@ -56,7 +56,7 @@ jobs:
             PYTHON_VERSION: '3.7'
             BUILD_TYPE: 'Release'
             PACKAGES: 'gcc-8 g++-8 gfortran-8 build-essential libmpich-dev mpich ccache graphviz'
-            BUILD_ARGS: '--minimal --build-libs shared --mpi --gotcha --stats --tools compiler --cxx-standard=17'
+            BUILD_ARGS: '--minimal --build-libs shared --mpi --gotcha --stats --tools compiler --cxx-standard=20'
             CTEST_ARGS: '-V --output-on-failure'
             CONFIG_ARGS: '-DTIMEMORY_CCACHE_BUILD=ON'
           - CC: gcc-9
@@ -65,7 +65,7 @@ jobs:
             PYTHON_VERSION: '3.7'
             BUILD_TYPE: 'MinSizeRel'
             PACKAGES: 'gcc-9 g++-9 gfortran-9 build-essential ccache graphviz'
-            BUILD_ARGS: '--minimal --build-libs shared --gotcha --stats --python --unwind --cxx-standard=17'
+            BUILD_ARGS: '--minimal --build-libs shared --gotcha --stats --python --unwind --cxx-standard=20'
             CTEST_ARGS: '-V --output-on-failure'
             CONFIG_ARGS: '-DTIMEMORY_CCACHE_BUILD=ON -DTIMEMORY_BUILD_PYTHON_UNITY=OFF'
           - CC: gcc-10
@@ -74,7 +74,7 @@ jobs:
             PYTHON_VERSION: '3.7'
             BUILD_TYPE: 'Release'
             PACKAGES: 'gcc-10 g++-10 gfortran-10 build-essential libtbb-dev ccache graphviz'
-            BUILD_ARGS: '--minimal --build-libs shared --python --arch --extra-optimizations --caliper --unwind --cxx-standard=17'
+            BUILD_ARGS: '--minimal --build-libs shared --python --arch --extra-optimizations --caliper --unwind --cxx-standard=20'
             CTEST_ARGS: '-V --output-on-failure'
             CONFIG_ARGS: '-DTIMEMORY_CCACHE_BUILD=ON -DTIMEMORY_BUILD_PYTHON_UNITY=OFF'
 
@@ -208,7 +208,7 @@ jobs:
             PYTHON_VERSION: '3.10'
             BUILD_TYPE: 'Release'
             PACKAGES: 'clang build-essential ccache graphviz'
-            BUILD_ARGS: '--minimal --build-libs shared --python --gotcha --unwind --stats --tools avail timem --cxx-standard=17'
+            BUILD_ARGS: '--minimal --build-libs shared --python --gotcha --unwind --stats --tools avail timem --cxx-standard=20'
             CTEST_ARGS: '-V --output-on-failure'
             CONFIG_ARGS: '-DTIMEMORY_CCACHE_BUILD=ON -DTIMEMORY_UNITY_BUILD=OFF -DTIMEMORY_BUILD_PYTHON_UNITY=OFF'
           - CC: gcc
@@ -217,7 +217,7 @@ jobs:
             PYTHON_VERSION: '3.10'
             BUILD_TYPE: 'Release'
             PACKAGES: 'gcc g++ gfortran build-essential ccache graphviz'
-            BUILD_ARGS: '--minimal --build-libs shared --python --gotcha --unwind --stats --tools avail timem --cxx-standard=17'
+            BUILD_ARGS: '--minimal --build-libs shared --python --gotcha --unwind --stats --tools avail timem --cxx-standard=20'
             CTEST_ARGS: '-V --output-on-failure'
             CONFIG_ARGS: '-DTIMEMORY_CCACHE_BUILD=ON -DTIMEMORY_UNITY_BUILD=OFF -DTIMEMORY_BUILD_PYTHON_UNITY=OFF'
 
@@ -347,7 +347,7 @@ jobs:
       matrix:
         include:
           - BUILD_TYPE: 'Release'
-            BUILD_ARGS: '--build-libs shared --tools avail timem --cxx-standard=17'
+            BUILD_ARGS: '--build-libs shared --tools avail timem --cxx-standard=20'
             CTEST_ARGS: '-V --output-on-failure'
             CONFIG_ARGS: '-DTIMEMORY_BUILD_{CALIPER,COMPILER_INSTRUMENTATION}=OFF -DTIMEMORY_BUILD_PYTHON_HATCHET=OFF'
             PYTHON_VERSION: '3.8'

--- a/cmake/Modules/Options.cmake
+++ b/cmake/Modules/Options.cmake
@@ -267,7 +267,7 @@ if(NOT BUILD_SHARED_LIBS AND NOT BUILD_STATIC_LIBS)
 endif()
 
 if(${PROJECT_NAME}_MAIN_PROJECT OR TIMEMORY_LANGUAGE_STANDARDS)
-    if("${CMAKE_CXX_STANDARD}" LESS 17)
+    if("${CMAKE_CXX_STANDARD}" LESS 20)
         unset(CMAKE_CXX_STANDARD CACHE)
     endif()
 
@@ -282,7 +282,7 @@ if(${PROJECT_NAME}_MAIN_PROJECT OR TIMEMORY_LANGUAGE_STANDARDS)
         11
         CACHE STRING "C language standard")
     set(CMAKE_CXX_STANDARD
-        17
+        20
         CACHE STRING "CXX language standard")
     if(CMAKE_VERSION VERSION_LESS 3.18.0)
         set(CMAKE_CUDA_STANDARD
@@ -308,7 +308,7 @@ if(${PROJECT_NAME}_MAIN_PROJECT OR TIMEMORY_LANGUAGE_STANDARDS)
     # extensions
     timemory_add_option(CMAKE_C_EXTENSIONS "C language standard extensions (e.g. gnu11)"
                         OFF)
-    timemory_add_option(CMAKE_CXX_EXTENSIONS "C++ language standard (e.g. gnu++17)"
+    timemory_add_option(CMAKE_CXX_EXTENSIONS "C++ language standard (e.g. gnu++20)"
                         ${_CXX_EXT})
     timemory_add_option(CMAKE_CUDA_EXTENSIONS "CUDA language standard (e.g. gnu++14)" OFF)
 else()
@@ -317,15 +317,15 @@ else()
     timemory_add_feature(CMAKE_CUDA_STANDARD_REQUIRED "Require C++ language standard")
     timemory_add_feature(CMAKE_C_EXTENSIONS "C language standard extensions (e.g. gnu11)")
     timemory_add_feature(CMAKE_CXX_EXTENSIONS
-                         "C++ language standard extensions (e.g. gnu++17)")
+                         "C++ language standard extensions (e.g. gnu++20)")
     timemory_add_feature(CMAKE_CUDA_EXTENSIONS "CUDA language standard (e.g. gnu++14)")
 
     if(NOT DEFINED CMAKE_CXX_STANDARD)
         timemory_message(
             AUTHOR_WARNING
-            "timemory requires settings CMAKE_CXX_STANDARD. Defaulting CMAKE_CXX_STANDARD to 17..."
+            "timemory requires settings CMAKE_CXX_STANDARD. Defaulting CMAKE_CXX_STANDARD to 20..."
             )
-        set(CMAKE_CXX_STANDARD 17)
+        set(CMAKE_CXX_STANDARD 20)
     endif()
 endif()
 

--- a/examples/ex-cxx-header-only/CMakeLists.txt
+++ b/examples/ex-cxx-header-only/CMakeLists.txt
@@ -4,7 +4,7 @@ project(timemory-Component-Example LANGUAGES C CXX)
 
 set(CMAKE_BUILD_TYPE "Release")
 set(CMAKE_UNITY_BUILD OFF)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)
 
 #

--- a/pyctest-runner.py
+++ b/pyctest-runner.py
@@ -356,7 +356,7 @@ def configure():
         "--cxx-standard",
         help="C++ standard",
         type=str,
-        default="17",
+        default="20",
         choices=("17", "20", "23"),
     )
     parser.add_argument(

--- a/scripts/macos-ci.sh
+++ b/scripts/macos-ci.sh
@@ -6,9 +6,9 @@ TIMEMORY_SOURCE_DIR=${2}
 : ${NPROC:=4}
 : ${CMAKE_ARGS:="-DTIMEMORY_BUILD_PYTHON_HATCHET=OFF"}
 if [ -n "$(which mpicc)" ]; then
-    : ${BUILD_ARGS:="--minimal --build-libs shared --python --mpi --cxx-standard=17"}
+    : ${BUILD_ARGS:="--minimal --build-libs shared --python --mpi --cxx-standard=20"}
 else
-    : ${BUILD_ARGS:="--minimal --build-libs shared --python --cxx-standard=17"}
+    : ${BUILD_ARGS:="--minimal --build-libs shared --python --cxx-standard=20"}
 fi
 
 if [ -z "${CONDA_PREFIX}" ]; then

--- a/setup.py
+++ b/setup.py
@@ -273,7 +273,7 @@ add_arg_bool_option("pybind-install", "PYBIND11_INSTALL", default=False)
 add_arg_bool_option("build-testing", "TIMEMORY_BUILD_TESTING")
 parser.add_argument(
     "--cxx-standard",
-    default=17,
+    default=20,
     type=int,
     choices=[17, 20, 23],
     help="Set C++ language standard",

--- a/source/timemory/storage/graph.hpp
+++ b/source/timemory/storage/graph.hpp
@@ -251,6 +251,34 @@ public:
         using iterator_base::parent;
     };
 
+    // C++20 disambiguation: sibling_iterator and pre_order_iterator are
+    // mutually convertible via iterator_base. Without explicit cross-type
+    // operators, the C++20 rewritten/reversed-candidate rule makes both
+    // same-type operator==/!= viable through implicit conversion of either
+    // operand, which GCC 11/12 reports as "ambiguous overload". Resolve by
+    // providing dedicated cross-type operators that compare the underlying
+    // node pointers, matching the same-type semantics at lines 2496-2528.
+    friend bool operator==(const sibling_iterator& lhs,
+                           const pre_order_iterator& rhs)
+    {
+        return lhs.node == rhs.node;
+    }
+    friend bool operator!=(const sibling_iterator& lhs,
+                           const pre_order_iterator& rhs)
+    {
+        return lhs.node != rhs.node;
+    }
+    friend bool operator==(const pre_order_iterator& lhs,
+                           const sibling_iterator& rhs)
+    {
+        return lhs.node == rhs.node;
+    }
+    friend bool operator!=(const pre_order_iterator& lhs,
+                           const sibling_iterator& rhs)
+    {
+        return lhs.node != rhs.node;
+    }
+
     /// Return iterator to the beginning of the graph.
     inline pre_order_iterator begin() const;
 

--- a/source/timemory/storage/graph.hpp
+++ b/source/timemory/storage/graph.hpp
@@ -251,13 +251,6 @@ public:
         using iterator_base::parent;
     };
 
-    // C++20 disambiguation: sibling_iterator and pre_order_iterator are
-    // mutually convertible via iterator_base. Without explicit cross-type
-    // operators, the C++20 rewritten/reversed-candidate rule makes both
-    // same-type operator==/!= viable through implicit conversion of either
-    // operand, which GCC 11/12 reports as "ambiguous overload". Resolve by
-    // providing dedicated cross-type operators that compare the underlying
-    // node pointers, matching the same-type semantics at lines 2496-2528.
     friend bool operator==(const sibling_iterator& lhs,
                            const pre_order_iterator& rhs)
     {

--- a/source/timemory/storage/impl_storage_false.cpp
+++ b/source/timemory/storage/impl_storage_false.cpp
@@ -281,7 +281,9 @@ storage<Type, false>::get_shared_manager()
         // replace spaces with underscores
         auto _pos = std::string::npos;
         while((_pos = _label.find_first_of(" -")) != std::string::npos)
-            _label = _label.replace(_pos, 1, "_");
+        {
+            _label[_pos] = '_';
+        }
         // convert to upper-case
         for(auto& itr : _label)
             itr = toupper(itr);

--- a/source/timemory/storage/impl_storage_false.cpp
+++ b/source/timemory/storage/impl_storage_false.cpp
@@ -281,9 +281,7 @@ storage<Type, false>::get_shared_manager()
         // replace spaces with underscores
         auto _pos = std::string::npos;
         while((_pos = _label.find_first_of(" -")) != std::string::npos)
-        {
             _label[_pos] = '_';
-        }
         // convert to upper-case
         for(auto& itr : _label)
             itr = toupper(itr);

--- a/source/timemory/tpls/cereal/cereal/cereal.hpp
+++ b/source/timemory/tpls/cereal/cereal/cereal.hpp
@@ -482,7 +482,7 @@ private:
     template <class T>
     inline ArchiveType& processImpl(DeferredData<T> const& d)
     {
-        std::function<void(void)> deferment([=]() { self->process(d.value); });
+        std::function<void(void)> deferment([=, this]() { self->process(d.value); });
         itsDeferments.emplace_back(std::move(deferment));
 
         return *self;
@@ -917,7 +917,7 @@ private:
     template <class T>
     inline ArchiveType& processImpl(DeferredData<T> const& d)
     {
-        std::function<void(void)> deferment([=]() { self->process(d.value); });
+        std::function<void(void)> deferment([=, this]() { self->process(d.value); });
         itsDeferments.emplace_back(std::move(deferment));
 
         return *self;

--- a/source/timemory/utility/filepath.cpp
+++ b/source/timemory/utility/filepath.cpp
@@ -177,18 +177,24 @@ makedir(std::string _dir, int umask)
 TIMEMORY_UTILITY_INLINE std::string&
                         replace(std::string& _path, char _c, const char* _v)
 {
-    auto _pos = std::string::npos;
+    // Take an owning copy of the replacement so the std::string overload
+    // of std::string::replace is selected (vs. const char*), which lets
+    // the compiler prove no aliasing with _path's buffer.
+    const std::string _to{ _v };
+    auto              _pos = std::string::npos;
     while((_pos = _path.find(_c)) != std::string::npos)
-        _path.replace(_pos, 1, _v);
+        _path.replace(_pos, 1, _to);
     return _path;
 }
 
 TIMEMORY_UTILITY_INLINE std::string&
                         replace(std::string& _path, const char* _c, const char* _v)
 {
-    auto _pos = std::string::npos;
-    while((_pos = _path.find(_c)) != std::string::npos)
-        _path.replace(_pos, strlen(_c), _v);
+    const std::string _from{ _c };
+    const std::string _to{ _v };
+    auto              _pos = std::string::npos;
+    while((_pos = _path.find(_from)) != std::string::npos)
+        _path.replace(_pos, _from.size(), _to);
     return _path;
 }
 
@@ -210,9 +216,7 @@ TIMEMORY_UTILITY_INLINE std::string
                         osrepr(std::string _path)
 {
     // OS-dependent representation
-    while(_path.find('/') != std::string::npos)
-        _path.replace(_path.find('/'), 1, "\\");
-    return _path;
+    return replace(_path, '/', "\\");
 }
 
 #elif defined(TIMEMORY_UNIX)
@@ -233,11 +237,8 @@ TIMEMORY_UTILITY_INLINE std::string
 osrepr(std::string _path)
 {
     // OS-dependent representation
-    while(_path.find("\\\\") != std::string::npos)
-        _path.replace(_path.find("\\\\"), 2, "/");
-    while(_path.find('\\') != std::string::npos)
-        _path.replace(_path.find('\\'), 1, "/");
-    return _path;
+    replace(_path, "\\\\", "/");
+    return replace(_path, '\\', "/");
 }
 
 #endif
@@ -257,7 +258,10 @@ TIMEMORY_UTILITY_INLINE std::string
     replace(_path, "//", "/");
 
     if(_path.find("./") == 0)
-        _path = _path.replace(0, 1, get_cwd());
+    {
+        const auto _cwd = get_cwd();
+        _path.replace(0, 1, _cwd);
+    }
     else if(_path.find("../") == 0)
         _path = _path.insert(0, get_cwd() + "/");
 
@@ -290,16 +294,13 @@ TIMEMORY_UTILITY_INLINE std::string
 {
 #if defined(TIMEMORY_UNIX)
     // _fname = realpath(_fname, nullptr, false);
-    while(_fname.find("\\\\") != std::string::npos)
-        _fname.replace(_fname.find("\\\\"), 2, "/");
-    while(_fname.find('\\') != std::string::npos)
-        _fname.replace(_fname.find('\\'), 1, "/");
+    replace(_fname, "\\\\", "/");
+    replace(_fname, '\\', "/");
 
     auto _pos = _fname.find_last_of('/');
     return (_pos != std::string::npos) ? _fname.substr(0, _pos) : _fname;
 #elif defined(TIMEMORY_WINDOWS)
-    while(_fname.find('/') != std::string::npos)
-        _fname.replace(_fname.find('/'), 1, "\\");
+    replace(_fname, '/', "\\");
 
     _fname = _fname.substr(0, _fname.find_last_of('\\'));
     return (_fname.at(_fname.length() - 1) == '\\')

--- a/source/tools/kokkos-connector/CMakeLists.txt
+++ b/source/tools/kokkos-connector/CMakeLists.txt
@@ -45,13 +45,13 @@ endif()
 set(BUILD_SHARED_LIBS ON)
 set(BUILD_STATIC_LIBS OFF)
 set(CMAKE_CXX_STANDARD
-    17
+    20
     CACHE STRING "CXX language standard")
 set(CMAKE_CXX_STANDARD_REQUIRED
     ON
     CACHE BOOL "CXX language flags required")
 set(CMAKE_CUDA_STANDARD
-    17
+    20
     CACHE STRING "CUDA language standard")
 set(CMAKE_CUDA_STANDARD_REQUIRED
     ON

--- a/spack/package.py
+++ b/spack/package.py
@@ -75,8 +75,8 @@ class Timemory(CMakePackage, PythonPackage):
                          '(min/max/stddev)'))
     variant('extra_optimizations', default=True,
             description='Build timemory with extra optimization flags')
-    variant('cxxstd', default='14', description='C++ language standard',
-            values=('14', '17', '20'), multi=False)
+    variant('cxxstd', default='20', description='C++ language standard',
+            values=('17', '20', '23'), multi=False)
     variant('mpip_library', default=False,
             description='Build stand-alone timemory-mpip GOTCHA library')
     variant('ompt', default=False, description=('Enable OpenMP tools support'))


### PR DESCRIPTION
## Motivation

Land C++20 support on the rocprofiler-systems consumer branch.

The standard bump itself (commit "Update C++ standard from C++17 to C++20") was previously isolated on the `upgrade-cpp-standard-to-c++20` branch. Bringing it onto `rocprofiler-systems` requires the additional cascade fixes that GCC 11/12 strict builds expose downstream.

## Technical Details

Five commits:

1. `Update C++ standard from C++17 to C++20` (cherry-picked from `upgrade-cpp-standard-to-c++20`).
2. `Disambiguate cross-type iterator comparisons under C++20` (graph.hpp): explicit hidden-friend `operator==` / `operator!=` for `sibling_iterator` vs `pre_order_iterator`. Fixes GCC 11/12 ambiguity from the C++20 reversed-candidate rule.
3. `Avoid GCC 12 -Wrestrict false positive in storage::get_shared_manager` (impl_storage_false.cpp): replace single-character `_label = _label.replace(_pos, 1, "_")` self-assign with direct subscript `_label[_pos] = '_'`. Bypasses the char_traits::copy path GCC 12 mis-analyzes.
4. `Drop braces on while-body in get_shared_manager`: style fix in the same loop.
5. `Avoid GCC 12 -Wrestrict false positive in filepath.cpp`: rewrite the two `replace()` helpers to take owning `std::string` copies of search and replacement values so the `std::string` overload of `string::replace` is selected (analyzer sees no aliasing). Inline `osrepr()` and `dirname()` patterns delegate to the helpers instead of repeating the workaround. No `#pragma` suppression.

## Test Plan

- Local debian 6.4 (GCC 12) container build of rocprofiler-systems with this timemory pin: clean.
- Local RHEL 8.10 (GCC 10.3.1) container build: clean.
- Existing timemory test suite must pass.

## Test Result

Awaiting CI.

## Submission Checklist

- [x] Look over the contributing guidelines.
