### PR TITLE
[Timemory] Fix mkdir race condition

### DIFF
--- a/source/timemory/utility/filepath.cpp
+++ b/source/timemory/utility/filepath.cpp
@@ -136,7 +136,9 @@ makedir(std::string _dir, int umask)
                 if(!direxists(_base))
                 {
                     auto _err = _make_dir(_base);
-                    if(_err != 0)
+                    // If two competing MPI ranks call makedir() on same dir
+                    // simultaneously, first rank creates dir, second gets EEXIST
+                    if(_err != 0 && _err != EEXIST)
                     {
                         TIMEMORY_PRINTF_WARNING(stderr, "mkdir(\"%s\", %i) failed: %s\n",
                                                 _base.c_str(), umask, strerror(_err));
@@ -218,19 +220,19 @@ TIMEMORY_UTILITY_INLINE std::string
 #elif defined(TIMEMORY_UNIX)
 
 TIMEMORY_UTILITY_INLINE std::string
-os()
+                        os()
 {
     return "/";
 }
 
 TIMEMORY_UTILITY_INLINE std::string
-inverse()
+                        inverse()
 {
     return "\\";
 }
 
 TIMEMORY_UTILITY_INLINE std::string
-osrepr(std::string _path)
+                        osrepr(std::string _path)
 {
     // OS-dependent representation
     while(_path.find("\\\\") != std::string::npos)

--- a/source/timemory/utility/filepath.cpp
+++ b/source/timemory/utility/filepath.cpp
@@ -220,19 +220,19 @@ TIMEMORY_UTILITY_INLINE std::string
 #elif defined(TIMEMORY_UNIX)
 
 TIMEMORY_UTILITY_INLINE std::string
-                        os()
+os()
 {
     return "/";
 }
 
 TIMEMORY_UTILITY_INLINE std::string
-                        inverse()
+inverse()
 {
     return "\\";
 }
 
 TIMEMORY_UTILITY_INLINE std::string
-                        osrepr(std::string _path)
+osrepr(std::string _path)
 {
     // OS-dependent representation
     while(_path.find("\\\\") != std::string::npos)


### PR DESCRIPTION
## Motivation

When two or more MPI ranks of a rocprof-sys-sample (or rocprof-sys-run) job initialize their sampling offload tmp file at roughly the same instant, they race on creating the shared /tmp/... parent directory. The "loser" of the race sees errno == EEXIST from mkdir(), which the path-creation helper currently treats as a hard failure. This causes tmp_file::open() to return false, which under ROCPROFSYS_CI=ON triggers an immediate std::abort(). The signal propagates up through mpiexec, tearing down the entire MPI job.

## Technical Details

This PR fixed this race condition by not treating EEXIST as an error. The purpose of the function is to create a folder, and EEXIST actually means that the folder is already created.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
